### PR TITLE
Remove Post method when using StripeToken to verify Payment. 

### DIFF
--- a/components/AppCheckout.vue
+++ b/components/AppCheckout.vue
@@ -70,40 +70,9 @@ export default {
   },
   methods: {
     pay() {
-      createToken().then(data => {
-        this.submitted = true;
-        console.log(data.token); //this is a token we would use for the stripeToken below
-        axios
-          .post(
-            'https://sdras-stripe.azurewebsites.net/api/charge?code=zWwbn6LLqMxuyvwbWpTFXdRxFd7a27KCRCEseL7zEqbM9ijAgj1c1w==',
-            {
-              stripeEmail: this.stripeEmail,
-              stripeToken: 'tok_visa', //testing token
-              stripeAmt: this.total
-            },
-            {
-              headers: {
-                'Content-Type': 'application/json'
-              }
-            }
-          )
-          .then(response => {
-            this.status = 'success';
-            this.$emit('successSubmit');
-            this.$store.commit('clearCartCount');
-
-            //console logs for you :)
-            this.response = JSON.stringify(response, null, 2);
-            console.log(this.response);
-          })
-          .catch(error => {
-            this.status = 'failure';
-
-            //console logs for you :)
-            this.response = 'Error: ' + JSON.stringify(error, null, 2);
-            console.log(this.response);
-          });
-      });
+      this.status = 'success';
+      this.$emit('successSubmit');
+      this.$store.commit('clearCartCount');
     },
     clearCart() {
       this.submitted = false;


### PR DESCRIPTION
Remove the Post method when using StripeToken to verify Payment. We have hard code always pass to Pay with credit card.